### PR TITLE
add: fetchWithAuth 함수 추가

### DIFF
--- a/src/components/utils/fetchWithAuth.tsx
+++ b/src/components/utils/fetchWithAuth.tsx
@@ -1,0 +1,81 @@
+import { useNavigate } from 'react-router-dom'
+
+let isRefreshing = false
+let refreshPromise: Promise<boolean> | null = null
+
+async function fetchWithAuth(input: RequestInfo, init?: RequestInit): Promise<Response> {
+  const modifiedInit: RequestInit = {
+    ...init,
+    headers: {
+      ...(init?.headers || {}),
+      Authorization: `Bearer ${localStorage.getItem("accessToken")}`,
+      "Content-Type": "application/json",
+    }
+  }
+
+  let response = await fetch(input, modifiedInit)
+
+  if (response.status !== 401) return response
+
+  // accessToken 만료 시도
+  if (!isRefreshing) {
+    isRefreshing = true
+    refreshPromise = tryRefreshToken().finally(() => {
+      isRefreshing = false
+    })
+  }
+
+  const refreshResult = await refreshPromise
+
+  if (!refreshResult) {
+    throw new Error("Token refresh failed")
+  }
+
+  // 재요청
+  const retryInit: RequestInit = {
+    ...init,
+    headers: {
+      ...(init?.headers || {}),
+      Authorization: `Bearer ${localStorage.getItem("accessToken")}`,
+      "Content-Type": "application/json",
+    }
+  }
+
+  return fetch(input, retryInit)
+}
+
+async function tryRefreshToken(): Promise<boolean> {
+	const navigate = useNavigate()
+	const refreshToken = localStorage.getItem("refreshToken")
+	if (!refreshToken) {
+		alert("로그인이 필요합니다.")
+		navigate("/")
+	}
+
+  try {
+    const res = await fetch(`${import.meta.env.VITE_API_BASE}/auth/refresh`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ refreshToken }),
+    })
+
+    if (!res.ok){
+      alert("로그인 세션이 만료되었습니다.")
+		  navigate("/")
+    }
+
+    const data = await res.json()
+    if (data.accessToken && data.refreshToken) {
+      localStorage.setItem("accessToken", data.accessToken)
+      localStorage.setItem("refreshToken", data.refreshToken)
+      return true
+    }
+
+    return false
+  } 
+  catch {
+    return false
+  }
+}
+
+export default fetchWithAuth


### PR DESCRIPTION
## 📍 PR Type
 - [x] 기능 추가
 - [ ] 버그 수정
 - [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
 - [ ] 기타 사소한 수정


## 📌 Related Issue
#21 
## 🚀 Description
accessToken 이 필요한 REST api 요청시 사용 가능한 함수 구현
- refreshToken 을 통해 accessToken 이 만료 시 자동 갱신 후 다시 해당 요청을 수행
- refreshToken 이 만료 시 alert 을 띄운 뒤 /home 으로 리다이렉트
## 📸 Screenshot

## 📢 Notes
accessToken 및 refreshToken 미구현 문제로 정상 작동 되는지 여부 확인 필요