### PR TITLE
[FEAT] 대기 방 관련 로직 url pramas 기준으로 변경

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,7 @@ function App() {
       <Route path="/verify" element={<ProtectedRoute><VerifyPage /></ProtectedRoute>} />
       <Route path="/lobby" element={<ProtectedRoute><LobbyPage /></ProtectedRoute>} />
       <Route path="/rooms" element={<ProtectedRoute><RoomListPage /></ProtectedRoute>} />
+      <Route path="/room/:roomid" element={<ProtectedRoute><RoomListPage /></ProtectedRoute>} />
       <Route path="/game/:gameid" element={<ProtectedRoute><GamePage /></ProtectedRoute>} />
       <Route path="/*" element={<NotFoundPage />} />
     </Routes>

--- a/src/components/pages/rooms/RoomModal.tsx
+++ b/src/components/pages/rooms/RoomModal.tsx
@@ -26,7 +26,6 @@ function RoomModal({ isOpen, onClose, roomId }: ModalProps) {
 	if (!isOpen) return null // 모달이 닫혀 있으면 렌더링 안 함
   
 	const	[participants, setParticipants] = useState<participants[]>([])
-	const [roomTitle, setRoomTitle] = useState<string>("")
 	const [roomType, setRoomType] = useState<string>("2P")
 	const	[inRoom, setInRoom] = useState<boolean>(false)
 	const navigate = useNavigate()
@@ -40,7 +39,6 @@ function RoomModal({ isOpen, onClose, roomId }: ModalProps) {
 			}
 
 			const data = await res.json()
-			setRoomTitle(data.name)
 			setRoomType(data.type)
 			setParticipants(data.participants)
 		} catch (error) {
@@ -65,12 +63,19 @@ function RoomModal({ isOpen, onClose, roomId }: ModalProps) {
 		fetchWithAuth(`${import.meta.env.VITE_API_BASE}/ft/api/tournaments/${roomId}/join`, {
 			method: "DELETE"})
 		.then((res) => {
-			if (!res.ok) throw new Error()
-			return
+			if (!res.ok) {
+				return res.json().then(errorData => {
+					throw new Error(errorData.message)
+				})
+			}
 		})
-		.catch(() => {
-			alert("오류가 발생했습니다.")
+		.catch((error) => {
+			if (error instanceof Error) {
+				alert(error.message)
+			}
+			else alert("오류가 발생했습니다.")
 			navigate("/lobby")
+			return
 		})
 		.finally(() => onClose())
 	}
@@ -94,16 +99,26 @@ const PlayerProfile = ({player1 = null, player2 = null}: Props) => {
 	return (
 		<div className="flex justify-center gap-[4vh]">
 			<div className="relative flex items-center justify-center flex-col">
-				<img
-					className="flex justify-center w-1/3"
-					src={BlackProfile} />
+				<div className="relative w-1/3">
+					<img
+						className="size-full"
+						src={BlackProfile} />
+					{player1 && <img
+						className="absolute inset-0 size-full rounded-full object-cover overflow-hidden"
+						src={player1.image} />}
+				</div>
 				<p className="text-white text-center text-2xl">{player1 ? player1.name : "???"}</p>
 			</div>
 			<p className="relative flex items-center justify-center text-2xl pb-3">VS</p>
 			<div className="relative flex items-center justify-center flex-col">
-				<img
-					className="flex justify-center w-1/3"
-					src={BlackProfile} />
+				<div className="relative w-1/3">
+					<img
+						className="size-full"
+						src={BlackProfile} />
+					{player2 && <img
+						className="absolute inset-0 size-full rounded-full object-cover overflow-hidden"
+						src={player2.image} />}
+					</div>
 				<p className="text-white text-center text-2xl">{player2 ? player2.name : "???"}</p>
 			</div>
 		</div>

--- a/src/components/pages/rooms/joinRoom.tsx
+++ b/src/components/pages/rooms/joinRoom.tsx
@@ -21,6 +21,8 @@ async function joinRoom(roomId: number): Promise<boolean> {
 
 		if (!res.ok) {
 			const errorData = await res.json()
+			if (errorData.errorCode === "TOURNAMENT_006")
+				return true
 			throw new Error(errorData.message)
 		}
 		return true


### PR DESCRIPTION
## 📍 PR Type
 - [x] 기능 추가
 - [ ] 버그 수정
 - [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
 - [ ] 기타 사소한 수정


## 📌 Related Issue
close #45 
## 🚀 Description
방 목록에서 방 대기 화면을 띄울 때 기준을 url 의 roomid 파람으로 하도록 수정
- createRoom 에서 바로 방 대기화면으로 가기 용이함
- 방 중복 참여가 가능하지만 해당 방 대기 화면에서만 방을 나갈 수 있는 상황에서 이미 참여한 방 대기 화면 다시 띄우기 가능
- 필요하다면 참가하지 않은 상황에서 방의 구성원을 알게 만들 수 있음
- 잘못된 roomid 가 들어 왔을 때 lobby 페이지로 리다이렉트 설정함
## 📸 Screenshot

## 📢 Notes
웹 소켓 연결과 관련해서 추후 작업 필요