### PR TITLE
Feat/#39 Mypage 컴포넌트 구현

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,12 +5,14 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + React + TS</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Jersey+15&family=Rubik+Mono+One&display=swap" rel="stylesheet">
-
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Jersey+10&family=Jersey+15&family=Rubik+Mono+One&display=swap"
+      rel="stylesheet"
+    />
   </head>
   <body>
     <div id="root"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@react-oauth/google": "^0.12.1",
+        "axios": "^1.9.0",
         "qrcode.react": "^4.2.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -1695,6 +1696,11 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
     "node_modules/autoprefixer": {
       "version": "10.4.21",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz",
@@ -1730,6 +1736,16 @@
       },
       "peerDependencies": {
         "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
+      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -1802,6 +1818,18 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/callsites": {
@@ -1912,6 +1940,17 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
@@ -1997,6 +2036,14 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/didyoumean": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
@@ -2008,6 +2055,19 @@
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "dev": true
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
@@ -2026,6 +2086,47 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.25.1",
@@ -2370,6 +2471,25 @@
       "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
       "dev": true
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
@@ -2384,6 +2504,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
+      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fraction.js": {
@@ -2417,7 +2551,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -2429,6 +2562,41 @@
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/glob": {
@@ -2499,6 +2667,17 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graphemer": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
@@ -2514,11 +2693,35 @@
         "node": ">=8"
       }
     },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -2786,6 +2989,14 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -2806,6 +3017,25 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/minimatch": {
@@ -3303,6 +3533,11 @@
           "optional": true
         }
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@react-oauth/google": "^0.12.1",
+    "axios": "^1.9.0",
     "qrcode.react": "^4.2.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/src/App.css
+++ b/src/App.css
@@ -1,3 +1,3 @@
 body {
-    font-family: 'Jersey 15', sans-serif;
-  }
+  font-family: 'Jersey 10', sans-serif;
+}

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -16,16 +16,33 @@ const Header = () => {
   const [isInvitationModal, setIsInvitationModal] = useState(false);
 
   const handleMainButton = () => {
-    navigate("/lobby");
+    navigate('/lobby');
   };
 
   return (
     <header className="fixed top-0 w-full flex items-center justify-between bg-black/70 h-24">
-      <img src={HeaderLogo} alt="Header Logo" onClick={handleMainButton} className="cursor-pointer w-80 ml-0" />
+      <img
+        src={HeaderLogo}
+        alt="Header Logo"
+        onClick={handleMainButton}
+        className="cursor-pointer w-80 ml-0"
+      />
       <nav className="space-x-4 flex flex-row mr-3">
-        <img src={InvitationIcon} onClick={() => setIsInvitationModal(true)} className="w-10 mr-3" />
-        <img src={BuddyIcon} onClick={() => setIsBuddyModal(true)} className="w-10" />
-        <img src={MenuIcon} onClick={() => setIsMypageModal(true)} className="w-10" />
+        <img
+          src={InvitationIcon}
+          onClick={() => setIsInvitationModal(true)}
+          className="w-10 mr-3 cursor-pointer"
+        />
+        <img
+          src={BuddyIcon}
+          onClick={() => setIsBuddyModal(true)}
+          className="w-10 cursor-pointer"
+        />
+        <img
+          src={MenuIcon}
+          onClick={() => setIsMypageModal(true)}
+          className="w-10 cursor-pointer"
+        />
       </nav>
 
       <SideModal isOpen={isInvitationModal} onClose={() => setIsInvitationModal(false)}>

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -16,7 +16,7 @@ const Header = () => {
   const [isInvitationModal, setIsInvitationModal] = useState(false);
 
   const handleMainButton = () => {
-    navigate('/lobby');
+    navigate('/main');
   };
 
   return (

--- a/src/components/modal/MyPageContent.tsx
+++ b/src/components/modal/MyPageContent.tsx
@@ -76,9 +76,10 @@ const MypageContent = () => {
         <div className="text-6xl text-white">{userInfo.name}</div>
         <img src={SettingIcon} />
       </div>
+      <hr className="w-full h-[3px] bg-[#2c2c2c] my-2 border-none" />
 
       {/* 매치 기록 */}
-      <div className="mt-8 w-full max-w-2xl">
+      <div className="mt-2 w-full max-w-2xl">
         <h2 className="text-center text-yellow-200 text-3xl font-bold mb-6">Match History</h2>
 
         <div className="grid grid-cols-4 text-gray-400 text-lg font-semibold border-b border-gray-600 pb-2 mb-4">
@@ -95,15 +96,15 @@ const MypageContent = () => {
               className="grid grid-cols-4 items-center border-b border-gray-600 pb-2"
             >
               <div
-                className={`text-left font-bold ${match.isWinner ? 'text-green-400' : 'text-red-400'}`}
+                className={`text-left font-bold text-xl ${match.isWinner ? 'text-green-400' : 'text-red-400'}`}
               >
                 {match.isWinner ? 'win' : 'lose'}
               </div>
-              <div className="text-center text-white font-mono text-lg">
+              <div className="text-center text-white text-xl">
                 {match.myScore}:{match.opponentScore}
               </div>
               <div className="text-center text-white">{match.opponentName}</div>
-              <div className="text-right text-white font-mono">
+              <div className="text-right text-white text-xl">
                 {new Date(match.playedAt).toLocaleDateString('en-US', {
                   month: '2-digit',
                   day: '2-digit',
@@ -121,7 +122,7 @@ const MypageContent = () => {
               onClick={() => setCurrentPage((p) => Math.max(p - 1, 1))}
               className="px-3 py-1 rounded bg-gray-600 text-white disabled:opacity-50"
             >
-              이전
+              prev
             </button>
             {Array.from({ length: totalPages }, (_, i) => i + 1).map((page) => (
               <button
@@ -141,7 +142,7 @@ const MypageContent = () => {
               onClick={() => setCurrentPage((p) => Math.min(p + 1, totalPages))}
               className="px-3 py-1 rounded bg-gray-600 text-white disabled:opacity-50"
             >
-              다음
+              next
             </button>
           </div>
         )}
@@ -149,9 +150,9 @@ const MypageContent = () => {
 
       {/* 승패 */}
       <div className="flex flex-col justify-center items-center mt-8">
-        <h1 className="text-[#FFFBAA] text-3xl">Win/Lose Stats</h1>
-        <div className="text-lg text-white">win: {userInfo.wins}</div>
-        <div className="text-lg text-white">lose: {userInfo.losses}</div>
+        <h1 className="text-[#FFFBAA] text-3xl mb-4">Win/Lose Stats</h1>
+        <div className="text-3xl text-white mb-2">win {userInfo.wins}</div>
+        <div className="text-3xl text-white">lose {userInfo.losses}</div>
       </div>
     </div>
   );

--- a/src/components/modal/MyPageContent.tsx
+++ b/src/components/modal/MyPageContent.tsx
@@ -1,11 +1,62 @@
+import { useEffect, useState } from 'react';
+import fetchWithAuth from '../utils/fetchWithAuth'; // fetchWithAuth 경로 확인!
+import ProfilePlaceholder from '../../assets/black_profile.svg';
+
+type UserInfo = {
+  id: number;
+  name: string;
+  imgURL: string;
+  wins: number;
+  losses: number;
+};
+
 const MypageContent = () => {
-    return (
-      <div>
-        <h1 className="text-gray-500">My Page</h1>
-        {/* 여기 마이페이지 내용 추가 */}
-      </div>
-    );
-  };
-  
-  export default MypageContent;
-  
+  const [userInfo, setUserInfo] = useState<UserInfo | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchUserInfo = async () => {
+      try {
+        const response = await fetchWithAuth(`${import.meta.env.VITE_API_BASE}/ft/api/users/me`, {
+          method: 'GET',
+        });
+
+        console.log(response);
+
+        if (!response.ok) {
+          throw new Error('서버 오류');
+        }
+
+        const data = await response.json(); // ✅ 꼭 .json()으로 변환
+        console.log(data);
+        setUserInfo(data);
+      } catch (err: any) {
+        console.error('유저 정보 가져오기 실패', err);
+        setError(err.message || '에러가 발생했습니다.');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchUserInfo();
+  }, []);
+
+  if (loading) return <div>로딩 중...</div>;
+  if (error) return <div>에러 발생: {error}</div>;
+  if (!userInfo) return <div>유저 정보를 찾을 수 없습니다.</div>;
+
+  return (
+    <div className="flex flex-col items-center gap-4 p-6">
+      <h1 className="text-white">MyPage</h1>
+      <h2 className="text-2xl text-white font-bold mb-4">마이페이지</h2>
+      <div className="text-lg text-white">아이디: {userInfo.id}</div>
+      <div className="text-lg text-white">이름: {userInfo.name}</div>
+      <div className="text-lg text-white">win: {userInfo.wins}</div>
+      <div className="text-lg text-white">lose: {userInfo.losses}</div>
+      <img src={ProfilePlaceholder} />
+    </div>
+  );
+};
+
+export default MypageContent;

--- a/src/components/modal/MyPageContent.tsx
+++ b/src/components/modal/MyPageContent.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import fetchWithAuth from '../utils/fetchWithAuth';
 import ProfilePlaceholder from '../../assets/black_profile.svg';
 import SettingIcon from '../../assets/icon/setting.svg';
+import { mockMatches } from '../../mocks/matches';
 
 type UserInfo = {
   id: number;
@@ -20,7 +21,7 @@ type MatchInfo = {
   playedAt: string; // 날짜 문자열
 };
 
-type MatchesResponse = {
+export type MatchesResponse = {
   matches: MatchInfo[];
   total: number;
   page: number;
@@ -33,38 +34,23 @@ const MypageContent = () => {
   const [matches, setMatches] = useState<MatchInfo[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [currentPage, setCurrentPage] = useState(1);
+  const matchesPerPage = 5;
 
   useEffect(() => {
     const fetchData = async () => {
       try {
-        // 유저 정보 가져오기
-        const userResponse = await fetchWithAuth(
-          `${import.meta.env.VITE_API_BASE}/ft/api/users/me`,
-          { method: 'GET' },
-        );
+        // 실제 요청은 주석처리, mock 사용
+        // const userResponse = await fetchWithAuth(`${import.meta.env.VITE_API_BASE}/ft/api/users/me`, { method: 'GET' });
+        // const userData = await userResponse.json();
+        setUserInfo({ id: 1, name: 'chaoh', imgURL: '', wins: 3, losses: 2 });
 
-        if (!userResponse.ok) {
-          throw new Error('유저 정보 가져오기 실패');
-        }
-
-        const userData = await userResponse.json();
-        setUserInfo(userData);
-
-        // 매치 기록 가져오기
-        const matchesResponse = await fetchWithAuth(
-          `${import.meta.env.VITE_API_BASE}/ft/api/users/me/matches/history`,
-          { method: 'GET' },
-        );
-
-        if (!matchesResponse.ok) {
-          throw new Error('매치 기록 가져오기 실패');
-        }
-
-        const matchesData: MatchesResponse = await matchesResponse.json();
-        setMatches(matchesData.matches); // ✅ matchesData.matches로 저장
-      } catch (err: any) {
+        // const matchesResponse = await fetchWithAuth(`${import.meta.env.VITE_API_BASE}/ft/api/users/me/matches/history`, { method: 'GET' });
+        // const matchesData: MatchesResponse = await matchesResponse.json();
+        setMatches(mockMatches.matches);
+      } catch (err: unknown) {
         console.error('데이터 가져오기 실패', err);
-        setError(err.message || '에러가 발생했습니다.');
+        setError(err instanceof Error ? err.message : '알 수 없는 에러');
       } finally {
         setLoading(false);
       }
@@ -77,39 +63,93 @@ const MypageContent = () => {
   if (error) return <div>에러 발생: {error}</div>;
   if (!userInfo) return <div>유저 정보를 찾을 수 없습니다.</div>;
 
+  // Pagination
+  const totalPages = Math.ceil(matches.length / matchesPerPage);
+  const startIndex = (currentPage - 1) * matchesPerPage;
+  const currentMatches = matches.slice(startIndex, startIndex + matchesPerPage);
+
   return (
     <div className="flex flex-col items-center gap-4 p-6">
       {/* 유저 프로필 */}
       <div className="flex flex-row items-center gap-8">
         <img src={ProfilePlaceholder} className="w-[120px] h-[120px]" />
-        <div className="text-6xl text-white">chaoh</div>
+        <div className="text-6xl text-white">{userInfo.name}</div>
         <img src={SettingIcon} />
       </div>
 
       {/* 매치 기록 */}
       <div className="mt-8 w-full max-w-2xl">
-        <h3 className="text-2xl font-bold text-white mb-4">매치 기록</h3>
-        <div className="flex flex-col gap-2">
-          {matches.length === 0 ? (
-            <div className="text-white">매치 기록이 없습니다.</div>
-          ) : (
-            matches.map((match) => (
-              <div key={match.id} className="bg-gray-700 text-white p-4 rounded-md">
-                <div>상대: {match.opponentName}</div>
-                <div>
-                  스코어: {match.myScore} : {match.opponentScore}
-                </div>
-                <div>결과: {match.isWinner ? '승리' : '패배'}</div>
-                <div>플레이 날짜: {new Date(match.playedAt).toLocaleDateString()}</div>
-              </div>
-            ))
-          )}
+        <h2 className="text-center text-yellow-200 text-3xl font-bold mb-6">Match History</h2>
+
+        <div className="grid grid-cols-4 text-gray-400 text-lg font-semibold border-b border-gray-600 pb-2 mb-4">
+          <div className="text-left">Result</div>
+          <div className="text-center">Count</div>
+          <div className="text-center">vs</div>
+          <div className="text-right">Date</div>
         </div>
+
+        <div className="space-y-4">
+          {currentMatches.map((match) => (
+            <div
+              key={match.id}
+              className="grid grid-cols-4 items-center border-b border-gray-600 pb-2"
+            >
+              <div
+                className={`text-left font-bold ${match.isWinner ? 'text-green-400' : 'text-red-400'}`}
+              >
+                {match.isWinner ? 'win' : 'lose'}
+              </div>
+              <div className="text-center text-white font-mono text-lg">
+                {match.myScore}:{match.opponentScore}
+              </div>
+              <div className="text-center text-white">{match.opponentName}</div>
+              <div className="text-right text-white font-mono">
+                {new Date(match.playedAt).toLocaleDateString('en-US', {
+                  month: '2-digit',
+                  day: '2-digit',
+                })}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* 페이지네이션 */}
+        {totalPages > 1 && (
+          <div className="flex justify-center items-center mt-6 gap-2">
+            <button
+              disabled={currentPage === 1}
+              onClick={() => setCurrentPage((p) => Math.max(p - 1, 1))}
+              className="px-3 py-1 rounded bg-gray-600 text-white disabled:opacity-50"
+            >
+              이전
+            </button>
+            {Array.from({ length: totalPages }, (_, i) => i + 1).map((page) => (
+              <button
+                key={page}
+                onClick={() => setCurrentPage(page)}
+                className={`px-3 py-1 rounded ${
+                  currentPage === page
+                    ? 'bg-yellow-300 text-black font-bold'
+                    : 'bg-gray-700 text-white'
+                }`}
+              >
+                {page}
+              </button>
+            ))}
+            <button
+              disabled={currentPage === totalPages}
+              onClick={() => setCurrentPage((p) => Math.min(p + 1, totalPages))}
+              className="px-3 py-1 rounded bg-gray-600 text-white disabled:opacity-50"
+            >
+              다음
+            </button>
+          </div>
+        )}
       </div>
 
       {/* 승패 */}
-      <div className="flex flex-col justify-center items-center">
-        <h1 className="text-[#FFFBAA]">Win/Lose Stats</h1>
+      <div className="flex flex-col justify-center items-center mt-8">
+        <h1 className="text-[#FFFBAA] text-3xl">Win/Lose Stats</h1>
         <div className="text-lg text-white">win: {userInfo.wins}</div>
         <div className="text-lg text-white">lose: {userInfo.losses}</div>
       </div>

--- a/src/components/modal/MyPageContent.tsx
+++ b/src/components/modal/MyPageContent.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
-import fetchWithAuth from '../utils/fetchWithAuth'; // fetchWithAuth 경로 확인!
+import fetchWithAuth from '../utils/fetchWithAuth';
 import ProfilePlaceholder from '../../assets/black_profile.svg';
+import SettingIcon from '../../assets/icon/setting.svg';
 
 type UserInfo = {
   id: number;
@@ -10,36 +11,66 @@ type UserInfo = {
   losses: number;
 };
 
+type MatchInfo = {
+  id: number;
+  myScore: number;
+  opponentScore: number;
+  isWinner: boolean;
+  opponentName: string;
+  playedAt: string; // 날짜 문자열
+};
+
+type MatchesResponse = {
+  matches: MatchInfo[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+};
+
 const MypageContent = () => {
   const [userInfo, setUserInfo] = useState<UserInfo | null>(null);
+  const [matches, setMatches] = useState<MatchInfo[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    const fetchUserInfo = async () => {
+    const fetchData = async () => {
       try {
-        const response = await fetchWithAuth(`${import.meta.env.VITE_API_BASE}/ft/api/users/me`, {
-          method: 'GET',
-        });
+        // 유저 정보 가져오기
+        const userResponse = await fetchWithAuth(
+          `${import.meta.env.VITE_API_BASE}/ft/api/users/me`,
+          { method: 'GET' },
+        );
 
-        console.log(response);
-
-        if (!response.ok) {
-          throw new Error('서버 오류');
+        if (!userResponse.ok) {
+          throw new Error('유저 정보 가져오기 실패');
         }
 
-        const data = await response.json(); // ✅ 꼭 .json()으로 변환
-        console.log(data);
-        setUserInfo(data);
+        const userData = await userResponse.json();
+        setUserInfo(userData);
+
+        // 매치 기록 가져오기
+        const matchesResponse = await fetchWithAuth(
+          `${import.meta.env.VITE_API_BASE}/ft/api/users/me/matches/history`,
+          { method: 'GET' },
+        );
+
+        if (!matchesResponse.ok) {
+          throw new Error('매치 기록 가져오기 실패');
+        }
+
+        const matchesData: MatchesResponse = await matchesResponse.json();
+        setMatches(matchesData.matches); // ✅ matchesData.matches로 저장
       } catch (err: any) {
-        console.error('유저 정보 가져오기 실패', err);
+        console.error('데이터 가져오기 실패', err);
         setError(err.message || '에러가 발생했습니다.');
       } finally {
         setLoading(false);
       }
     };
 
-    fetchUserInfo();
+    fetchData();
   }, []);
 
   if (loading) return <div>로딩 중...</div>;
@@ -48,13 +79,40 @@ const MypageContent = () => {
 
   return (
     <div className="flex flex-col items-center gap-4 p-6">
-      <h1 className="text-white">MyPage</h1>
-      <h2 className="text-2xl text-white font-bold mb-4">마이페이지</h2>
-      <div className="text-lg text-white">아이디: {userInfo.id}</div>
-      <div className="text-lg text-white">이름: {userInfo.name}</div>
-      <div className="text-lg text-white">win: {userInfo.wins}</div>
-      <div className="text-lg text-white">lose: {userInfo.losses}</div>
-      <img src={ProfilePlaceholder} />
+      {/* 유저 프로필 */}
+      <div className="flex flex-row items-center gap-8">
+        <img src={ProfilePlaceholder} className="w-[120px] h-[120px]" />
+        <div className="text-6xl text-white">chaoh</div>
+        <img src={SettingIcon} />
+      </div>
+
+      {/* 매치 기록 */}
+      <div className="mt-8 w-full max-w-2xl">
+        <h3 className="text-2xl font-bold text-white mb-4">매치 기록</h3>
+        <div className="flex flex-col gap-2">
+          {matches.length === 0 ? (
+            <div className="text-white">매치 기록이 없습니다.</div>
+          ) : (
+            matches.map((match) => (
+              <div key={match.id} className="bg-gray-700 text-white p-4 rounded-md">
+                <div>상대: {match.opponentName}</div>
+                <div>
+                  스코어: {match.myScore} : {match.opponentScore}
+                </div>
+                <div>결과: {match.isWinner ? '승리' : '패배'}</div>
+                <div>플레이 날짜: {new Date(match.playedAt).toLocaleDateString()}</div>
+              </div>
+            ))
+          )}
+        </div>
+      </div>
+
+      {/* 승패 */}
+      <div className="flex flex-col justify-center items-center">
+        <h1 className="text-[#FFFBAA]">Win/Lose Stats</h1>
+        <div className="text-lg text-white">win: {userInfo.wins}</div>
+        <div className="text-lg text-white">lose: {userInfo.losses}</div>
+      </div>
     </div>
   );
 };

--- a/src/components/modal/MyPageContent.tsx
+++ b/src/components/modal/MyPageContent.tsx
@@ -1,33 +1,9 @@
 import { useEffect, useState } from 'react';
-import fetchWithAuth from '../utils/fetchWithAuth';
+// import fetchWithAuth from '../utils/fetchWithAuth';
 import ProfilePlaceholder from '../../assets/black_profile.svg';
 import SettingIcon from '../../assets/icon/setting.svg';
 import { mockMatches } from '../../mocks/matches';
-
-type UserInfo = {
-  id: number;
-  name: string;
-  imgURL: string;
-  wins: number;
-  losses: number;
-};
-
-type MatchInfo = {
-  id: number;
-  myScore: number;
-  opponentScore: number;
-  isWinner: boolean;
-  opponentName: string;
-  playedAt: string; // 날짜 문자열
-};
-
-export type MatchesResponse = {
-  matches: MatchInfo[];
-  total: number;
-  page: number;
-  limit: number;
-  totalPages: number;
-};
+import { MatchInfo, MatchesResponse, UserInfo } from '../../types/MyMatch';
 
 const MypageContent = () => {
   const [userInfo, setUserInfo] = useState<UserInfo | null>(null);

--- a/src/components/modal/SideModal.tsx
+++ b/src/components/modal/SideModal.tsx
@@ -29,8 +29,8 @@ const SideModal = ({ isOpen, onClose, children }: SideModalProps) => {
         }`}
         onClick={(e) => e.stopPropagation()}
       >
-        <button onClick={onClose} className="absolute top-4 right-4 text-gray-500 hover:text-black">
-          닫기
+        <button onClick={onClose} className="absolute top-4 right-4 text-white hover:text-black">
+          X
         </button>
         <div className="p-6">{children}</div>
       </div>

--- a/src/components/modal/SideModal.tsx
+++ b/src/components/modal/SideModal.tsx
@@ -24,15 +24,12 @@ const SideModal = ({ isOpen, onClose, children }: SideModalProps) => {
     >
       <div
         ref={modalRef}
-        className={`absolute right-0 top-0 h-full w-80 bg-black/90 shadow-xl z-50 transform transition-transform duration-300 ease-in-out ${
+        className={`absolute right-0 top-0 h-full w-[500px] bg-black/90 shadow-xl z-50 transform transition-transform duration-300 ease-in-out ${
           isOpen ? 'translate-x-0' : 'translate-x-full'
         }`}
         onClick={(e) => e.stopPropagation()}
       >
-        <button
-          onClick={onClose}
-          className="absolute top-4 right-4 text-gray-500 hover:text-black"
-        >
+        <button onClick={onClose} className="absolute top-4 right-4 text-gray-500 hover:text-black">
           닫기
         </button>
         <div className="p-6">{children}</div>

--- a/src/components/utils/fetchWithAuth.tsx
+++ b/src/components/utils/fetchWithAuth.tsx
@@ -1,33 +1,33 @@
-import { useNavigate } from 'react-router-dom'
+import { useNavigate } from 'react-router-dom';
 
-let isRefreshing = false
-let refreshPromise: Promise<boolean> | null = null
+let isRefreshing = false;
+let refreshPromise: Promise<boolean> | null = null;
 
 async function fetchWithAuth(input: RequestInfo, init?: RequestInit): Promise<Response> {
   const modifiedInit: RequestInit = {
     ...init,
     headers: {
       ...(init?.headers || {}),
-      Authorization: `Bearer ${localStorage.getItem("accessToken")}`,
-    }
-  }
+      Authorization: `Bearer ${localStorage.getItem('accessToken')}`,
+    },
+  };
 
-  let response = await fetch(input, modifiedInit)
+  const response = await fetch(input, modifiedInit);
 
-  if (response.status !== 401) return response
+  if (response.status !== 401) return response;
 
   // accessToken 만료 시도
   if (!isRefreshing) {
-    isRefreshing = true
+    isRefreshing = true;
     refreshPromise = tryRefreshToken().finally(() => {
-      isRefreshing = false
-    })
+      isRefreshing = false;
+    });
   }
 
-  const refreshResult = await refreshPromise
+  const refreshResult = await refreshPromise;
 
   if (!refreshResult) {
-    throw new Error("Token refresh failed")
+    throw new Error('Token refresh failed');
   }
 
   // 재요청
@@ -35,48 +35,47 @@ async function fetchWithAuth(input: RequestInfo, init?: RequestInit): Promise<Re
     ...init,
     headers: {
       ...(init?.headers || {}),
-      Authorization: `Bearer ${localStorage.getItem("accessToken")}`,
-      "Content-Type": "application/json",
-    }
-  }
+      Authorization: `Bearer ${localStorage.getItem('accessToken')}`,
+      'Content-Type': 'application/json',
+    },
+  };
 
-  return fetch(input, retryInit)
+  return fetch(input, retryInit);
 }
 
 async function tryRefreshToken(): Promise<boolean> {
-	const navigate = useNavigate()
-	const refreshToken = localStorage.getItem("refreshToken")
-	if (!refreshToken) {
-		alert("로그인이 필요합니다.")
-		navigate("/")
-	}
+  const navigate = useNavigate();
+  const refreshToken = localStorage.getItem('refreshToken');
+  if (!refreshToken) {
+    alert('로그인이 필요합니다.');
+    navigate('/');
+  }
 
   try {
     const res = await fetch(`${import.meta.env.VITE_API_BASE}/auth/refresh`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ refreshToken }),
-    })
+    });
 
-    if (!res.ok){
-      localStorage.removeItem("accessToken")
-      localStorage.removeItem("refreshToken")
-      alert("로그인 세션이 만료되었습니다.")
-		  navigate("/")
+    if (!res.ok) {
+      localStorage.removeItem('accessToken');
+      localStorage.removeItem('refreshToken');
+      alert('로그인 세션이 만료되었습니다.');
+      navigate('/');
     }
 
-    const data = await res.json()
+    const data = await res.json();
     if (data.accessToken && data.refreshToken) {
-      localStorage.setItem("accessToken", data.accessToken)
-      localStorage.setItem("refreshToken", data.refreshToken)
-      return true
+      localStorage.setItem('accessToken', data.accessToken);
+      localStorage.setItem('refreshToken', data.refreshToken);
+      return true;
     }
 
-    return false
-  } 
-  catch {
-    return false
+    return false;
+  } catch {
+    return false;
   }
 }
 
-export default fetchWithAuth
+export default fetchWithAuth;

--- a/src/mocks/matches.ts
+++ b/src/mocks/matches.ts
@@ -1,0 +1,16 @@
+import { MatchesResponse } from '../components/modal/MyPageContent';
+
+export const mockMatches: MatchesResponse = {
+  matches: Array.from({ length: 18 }, (_, i) => ({
+    id: i + 1,
+    myScore: Math.floor(Math.random() * 6),
+    opponentScore: Math.floor(Math.random() * 6),
+    isWinner: Math.random() > 0.5,
+    opponentName: `opponent${i + 1}`,
+    playedAt: `2025-04-${String(27 + (i % 5)).padStart(2, '0')}`,
+  })),
+  total: 18,
+  page: 1,
+  limit: 5,
+  totalPages: Math.ceil(18 / 5), // = 4
+};

--- a/src/types/MyMatch.ts
+++ b/src/types/MyMatch.ts
@@ -1,0 +1,24 @@
+export type UserInfo = {
+  id: number;
+  name: string;
+  imgURL: string;
+  wins: number;
+  losses: number;
+};
+
+export type MatchInfo = {
+  id: number;
+  myScore: number;
+  opponentScore: number;
+  isWinner: boolean;
+  opponentName: string;
+  playedAt: string; // ISO string format
+};
+
+export type MatchesResponse = {
+  matches: MatchInfo[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+};


### PR DESCRIPTION
## 📍 PR Type
 - [x] 기능 추가
 - [ ] 버그 수정
 - [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
 - [ ] 기타 사소한 수정


## 📌 Related Issue
Resolve to #39 

## 🚀 Description
Mypage 컴포넌트를 구현하였습니다.
기본 모달 틀 내부에 MyPageContent를 띄우는 형식이고, user 정보, Match History, WinLoss Stats 를 렌더링합니다.
지금 서버 내부에 Match History 관련해서 데이터가 없어서 mock 데이터 넣어서 출력하도록 해놨고, 나중에 다시 데이터 받아오는 식으로 주석 풀면 됩니다!!

Match History는 5개씩 끊어서 페이지네이션 구현해두었습니다.
데이터가 5개보다 적으면 밑에 Win/Loss Stats 위치가 바뀌는데 이걸 나중에 수정할지 말지 고민이네요,,

그리고 여기서 사용하는 type들을 types/MyMatch.ts로 분리하였으니 참고하셔서 다른 데이터들도 비슷하게 정의하셔서 사용하시면 될 것 같습니다. 아래처럼 그냥 export 붙여서 따로 정의하시면 돼요!!

```typescript
//MyMatch.ts
export type UserInfo = {
  id: number;
  name: string;
  imgURL: string;
  wins: number;
  losses: number;
};

export type MatchInfo = {
  id: number;
  myScore: number;
  opponentScore: number;
  isWinner: boolean;
  opponentName: string;
  playedAt: string; // ISO string format
};

export type MatchesResponse = {
  matches: MatchInfo[];
  total: number;
  page: number;
  limit: number;
  totalPages: number;
};

``` 


## 📸 Screenshot
<img width="500" alt="image" src="https://github.com/user-attachments/assets/e5759da9-757b-4c5a-b1ad-7023efbca3e4" />


## 📢 Notes
