### PR TITLE
fix: 방 대기 창 수정

### DIFF
--- a/src/components/utils/fetchWithAuth.tsx
+++ b/src/components/utils/fetchWithAuth.tsx
@@ -12,6 +12,11 @@ async function fetchWithAuth(input: RequestInfo, navigate: (path: string) => voi
 
   const response = await fetch(input, modifiedInit)
 
+  if (response.status === 500) {
+    localStorage.removeItem('accessToken')
+    localStorage.removeItem('refreshToken')
+    navigate("/")
+  }
   if (response.status !== 401) return response
 
   // accessToken 만료 시도


### PR DESCRIPTION
## 📍 PR Type
 - [ ] 기능 추가
 - [ ] 버그 수정
 - [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
 - [ ] 기타 사소한 수정


## 📌 Related Issue
#62 
## 🚀 Description
방 대기창의 vs 를 없애고, 들어온 순서와 상관없이 항상 서버에서 주는 정보를 기준으로 설정
게임이 시작되면 매치 상대를 표시하고 2초 뒤 게임화면으로 전환, 1초 뒤 웹소켓 연결시도
## 📸 Screenshot
![Screenshot 2025-05-07 at 8 16 40 PM](https://github.com/user-attachments/assets/59b063c0-1675-4123-8be9-7f4983c6f818)
![Screenshot 2025-05-07 at 8 17 00 PM](https://github.com/user-attachments/assets/495fbf49-a848-4568-984b-df72389944f2)

## 📢 Notes
